### PR TITLE
Added logic to favor Loopback route.path to get route paths instead of raw url pathname

### DIFF
--- a/lib/rest-instrumentation.js
+++ b/lib/rest-instrumentation.js
@@ -6,7 +6,11 @@ module.exports = function initialize(shim, loopback) {
 
 function wrapHandleRequest(shim, original) {
     return async function wrappedHandleRequest(request, response) {
-        shim.setTransactionUri(request._parsedUrl.pathname);
+        const route = this.findRoute(request)
+        // try to get the actual route path from Loopback if not fallback to the
+        // IncomingMessage path
+        const uri = route && route.path || request._parsedUrl.pathname
+        shim.setTransactionUri(uri)
         return await original.apply(this, arguments)
     }
 }


### PR DESCRIPTION
I work on the New Relic Node.js agent team and a Technical Account Manager for Zest Money made me aware of an issue you were seeing with transaction URLs not being canonicalized.  I dug into this instrumentation and saw this was because it was using the raw URL path name.  You can see on this screenshot that the 2nd transaction is after applying this fix.  The rest were before the fix.  Enjoy!

<img width="518" alt="screenshot 2021-11-18 at 9 41 13 AM" src="https://user-images.githubusercontent.com/1874937/142436502-9b389f3a-2e77-44a4-a242-c8a06bbe4d11.png">

